### PR TITLE
Feature/#52 meeting delete

### DIFF
--- a/src/api/meeting.ts
+++ b/src/api/meeting.ts
@@ -244,8 +244,8 @@ export const getMeetingDetailWithParticipantEmails = async (
   try {
     const teamMembers = await getTeamMembers(String(meetingDetail.teamId));
 
-    const participantsWithEmail: MeetingParticipantWithName[] =
-      meetingDetail.participants.map((participant) => {
+    const participantsWithEmail: MeetingParticipantWithName[] = meetingDetail.participants.map(
+      (participant) => {
         const teamMember = teamMembers.find((m) => m.userId === participant.userId);
 
         return {
@@ -253,10 +253,10 @@ export const getMeetingDetailWithParticipantEmails = async (
           email: teamMember?.email || `user${participant.userId}@unknown.com`,
           userName: teamMember?.name ?? participant.userName,
           name: teamMember?.name ?? participant.userName, // (프론트 호환)
-          profileImageUrl:
-            teamMember?.profileImageUrl ?? participant.profileImageUrl ?? null, // ⬅️ 추가
+          profileImageUrl: teamMember?.profileImageUrl ?? participant.profileImageUrl ?? null, // ⬅️ 추가
         };
-      });
+      }
+    );
 
     return { ...meetingDetail, participants: participantsWithEmail };
   } catch (error) {
@@ -274,7 +274,6 @@ export const getMeetingDetailWithParticipantEmails = async (
     return { ...meetingDetail, participants: participantsWithPlaceholderEmail };
   }
 };
-
 
 export const getMeetingSummary = async (meetingId: number): Promise<MeetingSummaryResponse> => {
   const res = await axiosInstance.get<MeetingSummaryResponse>(
@@ -436,4 +435,9 @@ export const createRecommendations = async (meetingId: number, limit = 5): Promi
     null,
     { params: { limit } }
   );
+};
+
+// 회의 삭제
+export const deleteMeeting = async (meetingId: number): Promise<void> => {
+  await axiosInstance.delete(`/api/v1/meetings/${meetingId}`);
 };

--- a/src/components/internal/ui/popover.tsx
+++ b/src/components/internal/ui/popover.tsx
@@ -5,6 +5,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 
 export const Popover = PopoverPrimitive.Root;
 export const PopoverTrigger = PopoverPrimitive.Trigger;
+export const PopoverClose = PopoverPrimitive.Close;
 
 export const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -6,26 +6,34 @@ const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
 });
 
-axiosInstance.interceptors.request.use((config) => {
-  const token = localStorage.getItem('accessToken');
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
+// 요청 인터셉터
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('accessToken');
 
-  const auth = (config.headers?.Authorization || config.headers?.authorization) as
-    | string
-    | undefined;
-  const masked = auth ? auth.slice(0, 12) + '…' + auth.slice(-6) : 'none';
-  console.log(
-    '[dbg][REQ]',
-    config.method?.toUpperCase(),
-    config.baseURL,
-    config.url,
-    'Authorization=',
-    masked
-  );
-  return config;
-});
+    // reissue 요청이 아닐 경우에만 토큰을 헤더에 추가합니다.
+    if (token && !config.url?.endsWith('/auth/reissue')) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    // 디버깅용 로그 (필요 없으면 삭제 가능)
+    const auth = config.headers?.Authorization as string | undefined;
+    const masked = auth ? auth.slice(0, 12) + '…' + auth.slice(-6) : 'none';
+    console.log(
+      '[dbg][REQ]',
+      config.method?.toUpperCase(),
+      config.baseURL,
+      config.url,
+      'Authorization=',
+      masked
+    );
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
 
 // 응답 인터셉터: accessToken 만료 시 reissue → 재요청
 axiosInstance.interceptors.response.use(
@@ -35,17 +43,18 @@ axiosInstance.interceptors.response.use(
     const status = error.response?.status;
     const errorCode = error.response?.data?.code;
 
-    // 디버깅
+    // 👇 실패한 요청이 재발급 요청인지 확인하는 변수 추가
+    const isReissueRequest = originalRequest.url?.endsWith('/auth/reissue');
+
     console.log('Axios Interceptor Error:', error.response);
     console.log('Status:', status);
     console.log('Error Code:', errorCode);
-    // 디버깅
 
-    // 401 + USER-003 (refresh 대상) + 첫 시도일 때
     if (
       status === 401 &&
       (errorCode === 'USER-003' || errorCode === 'USER-006') &&
-      !originalRequest._retry
+      !originalRequest._retry &&
+      !isReissueRequest // 👈 [수정] 재발급 요청 실패 시에는 다시 시도하지 않도록 조건 추가
     ) {
       originalRequest._retry = true;
 
@@ -53,7 +62,6 @@ axiosInstance.interceptors.response.use(
         const refreshToken = localStorage.getItem('refreshToken');
         if (!refreshToken) throw new Error('No refresh token found');
 
-        // reissue 요청
         const newAccessToken = await reissueAccessToken(refreshToken);
         localStorage.setItem('accessToken', newAccessToken);
 
@@ -63,7 +71,9 @@ axiosInstance.interceptors.response.use(
         // 재발급 실패 → 토큰 초기화 후 로그인 페이지로 이동
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
-        window.location.href = '/auth/login';
+        if (typeof window !== 'undefined') {
+          window.location.href = '/auth/login';
+        }
         return Promise.reject(reissueError);
       }
     }


### PR DESCRIPTION
## #️⃣ Issue Number
Close #52 

## 📝 요약(Summary)
- 인증 로직 안정화: accessToken 및 refreshToken 만료 시 발생하던 여러 에러와 무한 루프 문제 해결
- 회의 삭제 기능 추가: 회의 전/후 상세 페이지에 회의 삭제 기능을 추가, 사용자 실수를 방지하기 위해 버튼 클릭 시 작은 확인 창(Popover)이 뜨도록 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경

## 📸스크린샷 (선택)
<img width="784" height="485" alt="스크린샷 2025-09-09 오전 1 28 09" src="https://github.com/user-attachments/assets/3130ac2e-e1a6-4aef-a1da-ec3314472a60" />
<img width="871" height="531" alt="스크린샷 2025-09-09 오전 1 32 10" src="https://github.com/user-attachments/assets/5c975066-2487-491e-a40a-001eb68d79ac" />


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
